### PR TITLE
修复了无法启动的问题，优化了Dialog

### DIFF
--- a/MCSL2.py
+++ b/MCSL2.py
@@ -1,5 +1,6 @@
 from json import dumps, loads
-from os import getcwd, mkdir, remove, sep
+from json import dumps, loads
+from os import getcwd, mkdir, sep
 from os import path as ospath
 from shutil import copy
 from sys import argv, exit
@@ -26,6 +27,7 @@ from MCSL2_MainWindow import *  # noqa: F403
 # Initialize MainWindow
 class MCSL2MainWindow(QMainWindow, Ui_MCSL2_MainWindow):
     def __init__(self):
+        InitMCSL()
         super(MCSL2MainWindow, self).__init__()
         self.setWindowFlags(self.windowFlags() | Qt.FramelessWindowHint)
         effect = QGraphicsDropShadowEffect(self)
@@ -78,6 +80,7 @@ class MCSL2MainWindow(QMainWindow, Ui_MCSL2_MainWindow):
         self.javaFindWorkThreadFactory.FinishSignalConnect = self.OnJavaFindWorkThreadFinished
         # create java finder workThread instance and start
         self.javaFindWorkThreadFactory.Create().start()
+
     def paintEvent(self, event):
         pat2 = QPainter(self)
         pat2.setRenderHint(pat2.Antialiasing)
@@ -669,7 +672,7 @@ class MCSL2MainWindow(QMainWindow, Ui_MCSL2_MainWindow):
                 print(type(GlobalServerList))
                 ServerCount = len(GlobalServerList)
                 print(ServerCount)
-                GlobalServerList[ServerCount+1] = {
+                GlobalServerList[ServerCount + 1] = {
                     "name": ServerName,
                     "core_file_name": CoreFileName,
                     "java_path": JavaPath,
@@ -710,7 +713,8 @@ class MCSL2MainWindow(QMainWindow, Ui_MCSL2_MainWindow):
     def JavaDetectFinished(self, _JavaPaths: list):
         global JavaPaths
         JavaPaths = _JavaPaths
-        with open(r"./MCSL2/AutoDetectJavaHistory.txt", 'w', encoding='utf-8') as SaveFoundedJava:
+
+        with open("MCSL2/AutoDetectJavaHistory.txt", 'w', encoding='utf-8') as SaveFoundedJava:
             SaveFoundedJava.writelines([p + '\n' for p in JavaPaths])
 
     @pyqtSlot(int)
@@ -724,7 +728,6 @@ class MCSL2MainWindow(QMainWindow, Ui_MCSL2_MainWindow):
         # 释放AutoDetectJava中禁用的按钮
         self.Auto_Find_Java_PushButton.setEnabled(True)
         # 更新self.ChooseJavaScrollAreaVerticalLayout中的内容
-
 
     def ShowFoundedJavaList_Back(self):
         self.FunctionsStackedWidget.setCurrentIndex(1)
@@ -1232,12 +1235,12 @@ class MCSL2MainWindow(QMainWindow, Ui_MCSL2_MainWindow):
 
         # 重新添加子控件
         if len(JavaPaths) == 0:
-            if ospath.exists(r"MCSL2/AutoDetectJavaHistory.txt"):
-                with open(r"./MCSL2/AutoDetectJavaHistory.txt", 'r', encoding='utf-8') as ReadFoundedJava:
+            if ospath.exists("MCSL2/AutoDetectJavaHistory.txt"):
+                with open("MCSL2/AutoDetectJavaHistory.txt", 'r', encoding='utf-8') as ReadFoundedJava:
                     FoundedJavaTMP = [p[:-1] for p in ReadFoundedJava.readlines()]
                     print(FoundedJavaTMP)
                     JavaPaths = FoundedJavaTMP
-                    
+
         for i in range(len(JavaPaths)):
             self.MCSL2_SubWidget_Select = QWidget()
             self.MCSL2_SubWidget_Select.setGeometry(QRect(150, 110, 620, 70))
@@ -1361,37 +1364,34 @@ class MCSL2MainWindow(QMainWindow, Ui_MCSL2_MainWindow):
 
 # Customize dialogs
 class MCSL2Dialog(QDialog, Ui_MCSL2_Dialog):
-    def __init__(self):
+    def __init__(self, Tip):
         super(MCSL2Dialog, self).__init__()
         self.setupUi(self)
+        self.Dialog_label.setText(Tip)
 
 
 class MCSL2AskDialog(QDialog, Ui_MCSL2_AskDialog):
-    def __init__(self):
+    def __init__(self, Tip):
         super(MCSL2AskDialog, self).__init__()
         self.setupUi(self)
+        self.Dialog_label.setText(Tip)
 
 
 # The function of calling MCSL2 Dialog
 def CallMCSL2Dialog(Tip, isNeededTwoButtons):
-    SaveTip = open(r"Tip", "w+")
-    SaveTip.write(Tip)
-    SaveTip.close()
     if isNeededTwoButtons == 0:
-        MCSL2Dialog().exec()
-        remove(r"Tip")
+        MCSL2Dialog(Tip).exec()
     elif isNeededTwoButtons == 1:
-        MCSL2AskDialog().exec()
-        remove(r"Tip")
+        MCSL2AskDialog(Tip).exec()
     else:
         pass
 
 
-def InitMCSL(isFirstLaunch):
-    if isFirstLaunch == 1:
+def InitMCSL():
+    if not ospath.exists(r"MCSL2"):
+        mkdir(r"MCSL2")
         CallMCSL2Dialog(Tip="请注意：\n\n本程序无法在125%的\n\nDPI缩放比下正常运行。\n(本提示仅在首次启动出现)",
                         isNeededTwoButtons=0)
-        mkdir(r"MCSL2")
         mkdir(r"MCSL2/Aria2")
         with open(r"./MCSL2/MCSL2_Config.json", "w+", encoding="utf-8") as InitConfig:
             ConfigTemplate = ""
@@ -1467,22 +1467,20 @@ def GetFileVersion(File):
     return Version
 
 
-# Start MCSL
-JavaPath = 0
-JavaPaths = []
-DiskSymbols = []
-SearchStatus = 0
-CorePath = ""
-DownloadSource = 0
-Version = "2.0.1"
+if __name__ == '__main__':
+    # Start MCSL
+    JavaPath = 0
+    JavaPaths = []
+    DiskSymbols = []
+    SearchStatus = 0
+    CorePath = ""
+    DownloadSource = 0
+    Version = "2.0.1"
 
-QApplication.setAttribute(Qt.AA_EnableHighDpiScaling, True)
-QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps, True)
-MCSLProcess = QApplication(argv)
-MCSLMainWindow = MCSL2MainWindow()
-MCSLMainWindow.show()
-if not ospath.exists(r"MCSL2"):
-    InitMCSL(isFirstLaunch=1)
-else:
-    InitMCSL(isFirstLaunch=0)
-exit(MCSLProcess.exec_())
+    QApplication.setAttribute(Qt.AA_EnableHighDpiScaling, True)
+    QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps, True)
+    MCSLProcess = QApplication(argv)
+    MCSLMainWindow = MCSL2MainWindow()
+    MCSLMainWindow.show()
+
+    exit(MCSLProcess.exec_())

--- a/MCSL2.py
+++ b/MCSL2.py
@@ -1,5 +1,5 @@
 from json import dumps, loads
-from os import getcwd, mkdir, remove, sep
+from os import getcwd, mkdir, sep
 from os import path as ospath
 from shutil import copy
 from sys import argv, exit

--- a/MCSL2_AskDialog.py
+++ b/MCSL2_AskDialog.py
@@ -122,6 +122,4 @@ class Ui_MCSL2_AskDialog(object):
         MCSL2_AskDialog.setWindowTitle(_translate("MCSL2_AskDialog", "提示"))
         self.Dialog_PushButton_Accept.setText(_translate("MCSL2_AskDialog", "确定"))
         self.Dialog_PushButton_Cancel.setText(_translate("MCSL2_AskDialog", "取消"))
-        Tip = open(r"Tip", "r").read()
-        self.Dialog_label.setText(_translate("MCSL2_AskDialog", Tip))
         self.Dialog_PushButton_Accept.clicked.connect(self.close)

--- a/MCSL2_Dialog.py
+++ b/MCSL2_Dialog.py
@@ -95,6 +95,4 @@ class Ui_MCSL2_Dialog(object):
         _translate = QCoreApplication.translate
         MCSL2_Dialog.setWindowTitle(_translate("MCSL2_Dialog", "提示"))
         self.Dialog_PushButton.setText(_translate("MCSL2_Dialog", "知道了"))
-        Tip = open(r"Tip", "r").read()
-        self.Dialog_label.setText(_translate("MCSL2_Dialog", Tip))
         self.Dialog_PushButton.clicked.connect(self.close)


### PR DESCRIPTION
不能启动的原因:
程序第一次运行没有MSCL2文件夹，创建文件夹的操作在InitMCSL函数里，而MainWindow的__init__里需要MCSL2文件夹，此时问题就出现了，由于初始化操作分开在两个函数里执行导致执行的顺序不对,__init__文件执行在前，InitMCSL执行在后（逻辑上不太一样，但的确是这么执行的），

解决不能启动的方法:
将InitMCSL2放到MainWindow的__init__函数中的最上部，保证了加载的顺序不会出错

测试了解决方法:
在MCSL2文件夹或者AutoDetectJavaHistory.txt缺失的情况下依然能按正确的逻辑运行，另外只用一个open(“w”)就可以实现覆写文件，with open中不需要close，因为当with语句结束会自动close

优化了Dialog:
CallMCSL2Dialog这个函数在调用时，是将Tip写入成文件而在CallMCSL2Dialog函数和MCSL2Dialog类初始化函数之间传递，但其实不用这么弯弯绕，将Tip传入MCSL2Dialog类的构造方法，在构造方法里重写一句self.Dialog_label.setText(Tip)就能形成相同的效果，避免的不必要的硬盘IO操作

最后：
落雪生病了好好休息，早日康复